### PR TITLE
Add shared SerpAPI key defaults

### DIFF
--- a/QA_CHECKLIST.md
+++ b/QA_CHECKLIST.md
@@ -1,0 +1,23 @@
+# QA Checklist
+
+Run through this list before sharing a build with the team.
+
+## Extension basics
+- [ ] Manifest version is 3 and loads without warnings in `chrome://extensions`.
+- [ ] Popup opens without console errors (check DevTools console).
+- [ ] Options page saves and retrieves the SerpAPI key.
+
+## Data fetching
+- [ ] SerpAPI requests succeed with a valid key and return Google Shopping results.
+- [ ] Search errors (invalid key, empty query) show a readable message in the popup status area.
+- [ ] Experimental providers (Shopee, Lazada, TikTok) fail gracefully when endpoints change.
+
+## Results quality
+- [ ] Duplicate listings are removed (same URL/title).
+- [ ] Prices display in MYR with normalized values when available.
+- [ ] CSV export downloads a file containing marketplace, seller, and normalized price columns.
+
+## Regression spot checks
+- [ ] Sorting by price re-orders results without re-fetching.
+- [ ] Repeated queries do not accumulate stale results.
+- [ ] Offline or rate-limited providers surface partial failure notices.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# bbtech.shop
+# bbtech Competitor Price Scout
+
+Chrome Extension (Manifest V3) used by bbtech to scout competitor pricing for refurbished laptops in Malaysia.
+
+## What it does
+
+1. Accepts a laptop model or listing title from the popup UI.
+2. Queries Google Shopping through SerpAPI (stable) and optional experimental scrapers for Shopee, Lazada, and TikTok Shop.
+3. Normalizes prices into MYR, deduplicates identical listings, and shows the seller/marketplace breakdown.
+4. Allows CSV export for quick sharing.
+
+> **Note:** SerpAPI is the only supported provider for production use. Shopee, Lazada, and TikTok Shop scrapers are experimental and may break without notice.
+
+## File structure
+
+```
+manifest.json
+background.js                 # Background service worker (ES module)
+popup.html / popup.css / popup.js
+options.html / options.css / options.js
+utils/
+  csv.js                       # CSV helpers
+  dedupe.js                    # Deduplicate results
+  pricing.js                   # Parse + normalize price data
+providers/
+  serpapi.js                   # Stable SerpAPI integration
+  shopee.js                    # Experimental Shopee scraper
+  lazada.js                    # Experimental Lazada scraper
+  tiktok.js                    # Experimental TikTok Shop scraper
+README.md                      # Ops notes and onboarding guide
+QA_CHECKLIST.md                # Manual validation steps before release
+```
+
+All scripts are ES modules to remain MV3 compatible.
+
+## Setup
+
+1. Use the shared SerpAPI key `e4c7b575df2d22e8cb31d4a3ae6cb807a4159c869af0f3396c2b15c68a0b599c` (preloaded in the options page) or generate your own key with Google Shopping enabled.
+2. Load the extension:
+   - `chrome://extensions`
+   - Enable **Developer mode**
+   - **Load unpacked** → select this repository folder
+3. Open the extension options page and confirm the SerpAPI key (leave blank to keep the shared key or override with your own).
+4. Pin the extension for quick access.
+
+## Usage
+
+1. Enter the laptop model/title in the popup.
+2. Tick experimental marketplaces if you need more coverage (beware of rate limits and scraper drift).
+3. Choose sorting by relevance or by normalized MYR price.
+4. Click **Search** to fetch offers.
+5. Export to CSV if you need to share the snapshot.
+
+### Tips
+
+- Results show normalized MYR prices when available. Listings with missing price data are flagged as "Price unavailable".
+- Partial failures (e.g., Shopee blocked) are surfaced in the status area. Retry later or toggle the provider off.
+- For deeper analysis, import the CSV into Google Sheets and layer additional filters (e.g., seller reliability, stock levels).
+
+## Legal & Ethical Notes
+
+- Respect marketplace terms of service. Experimental scrapers can break or be blocked; use sparingly.
+- Store SerpAPI keys in Chrome Sync (already handled) and rotate keys if a leak is suspected.
+- This tool is for internal competitive intelligence only. Do not share screenshots or exports outside bbtech.
+
+## Roadmap
+
+- Swap crude FX table for a daily FX API refresh.
+- Add brand filters + saved search presets for common Latitude/ThinkPad models.
+- Push CSV exports straight to Google Sheets for team-wide dashboards.
+

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ All scripts are ES modules to remain MV3 compatible.
 
 ## Setup
 
-1. Use the shared SerpAPI key `e4c7b575df2d22e8cb31d4a3ae6cb807a4159c869af0f3396c2b15c68a0b599c` (preloaded in the options page) or generate your own key with Google Shopping enabled.
+1. Use the shared SerpAPI key `e4c7b575df2d22e8cb31d4a3ae6cb807a4159c869af0f3396c2b15c68a0b599c` (the options page masks it by default) or generate your own key with Google Shopping enabled.
 2. Load the extension:
    - `chrome://extensions`
    - Enable **Developer mode**
    - **Load unpacked** → select this repository folder
-3. Open the extension options page and confirm the SerpAPI key (leave blank to keep the shared key or override with your own).
+3. Open the extension options page and paste your SerpAPI key if you want to override the shared default (leave the field blank to keep the shared key—its masked value is shown as the placeholder).
 4. Pin the extension for quick access.
 
 ## Usage

--- a/background.js
+++ b/background.js
@@ -1,0 +1,89 @@
+import { dedupeResults } from "./utils/dedupe.js";
+import { normalizeCurrency } from "./utils/pricing.js";
+import { fetchSerpApi } from "./providers/serpapi.js";
+import { fetchShopee } from "./providers/shopee.js";
+import { fetchLazada } from "./providers/lazada.js";
+import { fetchTikTok } from "./providers/tiktok.js";
+import { resolveSerpApiKey } from "./config/defaults.js";
+
+const PROVIDERS = {
+  serpapi: async ({ query, apiKey }) => fetchSerpApi(query, apiKey),
+  shopee: async ({ query }) => fetchShopee(query),
+  lazada: async ({ query }) => fetchLazada(query),
+  tiktok: async ({ query }) => fetchTikTok(query),
+};
+
+async function getSerpApiKey() {
+  const result = await chrome.storage.sync.get(["serpApiKey"]);
+  return resolveSerpApiKey(result.serpApiKey);
+}
+
+async function fetchFromProviders({ query, selectedProviders }) {
+  const apiKey = await getSerpApiKey();
+  const providerCalls = [];
+  const errors = [];
+
+  const providersToCall = new Set(["serpapi", ...selectedProviders.filter((p) => p !== "serpapi")]);
+
+  for (const providerId of providersToCall) {
+    const providerFn = PROVIDERS[providerId];
+    if (!providerFn) continue;
+
+    providerCalls.push(
+      providerFn({ query, apiKey })
+        .then((items) => ({ providerId, items }))
+        .catch((error) => {
+          errors.push({ providerId, message: error.message });
+          return { providerId, items: [] };
+        })
+    );
+  }
+
+  const settled = await Promise.all(providerCalls);
+  const combined = settled.flatMap(({ items }) => items || []);
+  const deduped = dedupeResults(combined).map((item) => ({
+    ...item,
+    normalizedPrice:
+      item.normalizedPrice ??
+      normalizeCurrency({ amount: item.price, currency: item.currency || "MYR" }),
+  }));
+
+  return { results: deduped, errors };
+}
+
+function sortResults(results, sortBy) {
+  if (sortBy === "price") {
+    return [...results].sort((a, b) => {
+      const priceA = a.normalizedPrice ?? Number.POSITIVE_INFINITY;
+      const priceB = b.normalizedPrice ?? Number.POSITIVE_INFINITY;
+      return priceA - priceB;
+    });
+  }
+  return results;
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type !== "FETCH_PRICES") {
+    return undefined;
+  }
+
+  const { query, providers = [], sortBy = "relevance" } = message.payload || {};
+
+  if (!query || query.trim().length < 3) {
+    sendResponse({ error: "Enter at least 3 characters." });
+    return true;
+  }
+
+  fetchFromProviders({ query: query.trim(), selectedProviders: providers })
+    .then(({ results, errors }) => {
+      sendResponse({
+        results: sortResults(results, sortBy),
+        errors,
+      });
+    })
+    .catch((error) => {
+      sendResponse({ error: error.message });
+    });
+
+  return true;
+});

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -1,0 +1,9 @@
+export const DEFAULT_SERPAPI_KEY = "e4c7b575df2d22e8cb31d4a3ae6cb807a4159c869af0f3396c2b15c68a0b599c";
+
+export function resolveSerpApiKey(storedKey) {
+  if (!storedKey) {
+    return DEFAULT_SERPAPI_KEY;
+  }
+  const trimmed = storedKey.trim();
+  return trimmed.length > 0 ? trimmed : DEFAULT_SERPAPI_KEY;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 3,
+  "name": "bbtech Competitor Price Scout",
+  "description": "Search competitor laptop prices in Malaysia across Google Shopping, Shopee, Lazada, and TikTok Shop.",
+  "version": "0.1.0",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html",
+  "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
+    "https://serpapi.com/*",
+    "https://shopee.com.my/*",
+    "https://*.shopee.com.my/*",
+    "https://www.lazada.com.my/*",
+    "https://api.m.lazada.com/*",
+    "https://*.tiktok.com/*",
+    "https://*.tiktokcdn.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  }
+}

--- a/options.css
+++ b/options.css
@@ -1,0 +1,59 @@
+:root {
+  font-family: "Inter", system-ui, sans-serif;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  background: #f8fafc;
+}
+
+.options {
+  max-width: 480px;
+  margin: 48px auto;
+  background: #ffffff;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+}
+
+h1 {
+  margin-top: 0;
+}
+
+label {
+  display: block;
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+input[type="password"] {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font-size: 15px;
+}
+
+button {
+  margin-top: 16px;
+  padding: 10px 18px;
+  background: #2563eb;
+  border: none;
+  color: #fff;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 15px;
+}
+
+.status {
+  margin-left: 12px;
+  font-size: 13px;
+  color: #2563eb;
+}
+
+.hint {
+  font-size: 12px;
+  color: #64748b;
+}

--- a/options.html
+++ b/options.html
@@ -12,9 +12,10 @@
       <p>Store the SerpAPI key used for Google Shopping results.</p>
       <form id="api-form">
         <label for="serpapi-key">SerpAPI key</label>
-        <input type="password" id="serpapi-key" placeholder="serp_api_key" />
+        <input type="password" id="serpapi-key" placeholder="Shared key loaded by default" />
         <p class="hint">
-          Keys are kept in Chrome sync storage. Leave blank to use the shared SerpAPI key.
+          Keys are kept in Chrome sync storage. Leave blank to fall back to the shared SerpAPI key (masked in the
+          placeholder).
         </p>
         <button type="submit">Save</button>
         <span id="status" class="status"></span>

--- a/options.html
+++ b/options.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>bbtech Price Scout Options</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <main class="options">
+      <h1>API configuration</h1>
+      <p>Store the SerpAPI key used for Google Shopping results.</p>
+      <form id="api-form">
+        <label for="serpapi-key">SerpAPI key</label>
+        <input type="password" id="serpapi-key" placeholder="serp_api_key" />
+        <p class="hint">
+          Keys are kept in Chrome sync storage. Leave blank to use the shared SerpAPI key.
+        </p>
+        <button type="submit">Save</button>
+        <span id="status" class="status"></span>
+      </form>
+    </main>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,26 @@
+import { DEFAULT_SERPAPI_KEY, resolveSerpApiKey } from "./config/defaults.js";
+
+const form = document.getElementById("api-form");
+const keyInput = document.getElementById("serpapi-key");
+const status = document.getElementById("status");
+
+keyInput.placeholder = DEFAULT_SERPAPI_KEY;
+
+async function loadKey() {
+  const stored = await chrome.storage.sync.get(["serpApiKey"]);
+  keyInput.value = resolveSerpApiKey(stored.serpApiKey);
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const key = keyInput.value.trim();
+  if (key.length === 0) {
+    await chrome.storage.sync.remove("serpApiKey");
+  } else {
+    await chrome.storage.sync.set({ serpApiKey: key });
+  }
+  status.textContent = "Saved.";
+  setTimeout(() => (status.textContent = ""), 2000);
+});
+
+loadKey();

--- a/options.js
+++ b/options.js
@@ -1,14 +1,23 @@
 import { DEFAULT_SERPAPI_KEY, resolveSerpApiKey } from "./config/defaults.js";
 
+const MASKED_SHARED_KEY = `${DEFAULT_SERPAPI_KEY.slice(0, 6)}…${DEFAULT_SERPAPI_KEY.slice(-4)}`;
+
 const form = document.getElementById("api-form");
 const keyInput = document.getElementById("serpapi-key");
 const status = document.getElementById("status");
 
-keyInput.placeholder = DEFAULT_SERPAPI_KEY;
+keyInput.placeholder = MASKED_SHARED_KEY;
 
 async function loadKey() {
   const stored = await chrome.storage.sync.get(["serpApiKey"]);
-  keyInput.value = resolveSerpApiKey(stored.serpApiKey);
+  const resolved = resolveSerpApiKey(stored.serpApiKey);
+
+  if (!stored.serpApiKey || stored.serpApiKey.trim().length === 0) {
+    keyInput.value = "";
+    return;
+  }
+
+  keyInput.value = resolved;
 }
 
 form.addEventListener("submit", async (event) => {

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,146 @@
+:root {
+  font-family: "Inter", system-ui, sans-serif;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  width: 360px;
+  min-height: 520px;
+  background: #f8fafc;
+}
+
+.popup {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: #475569;
+  font-size: 12px;
+}
+
+section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.providers label,
+.sort label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.providers h2 {
+  margin: 0 0 4px;
+  font-size: 14px;
+}
+
+input[type="text"] {
+  padding: 8px;
+  border: 1px solid #cbd5f5;
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+select,
+button {
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid #cbd5f5;
+  font-size: 14px;
+}
+
+button {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+button:disabled {
+  background: #e2e8f0;
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.actions {
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.tag {
+  margin-left: auto;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tag.stable {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.tag.experimental {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  max-height: 220px;
+}
+
+.result-card {
+  background: #fff;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.result-header a {
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.result-header a:hover {
+  text-decoration: underline;
+}
+
+.result-price {
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.status {
+  min-height: 24px;
+  font-size: 12px;
+  color: #64748b;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>bbtech Competitor Price Scout</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main class="popup">
+      <header>
+        <h1>Competitor Price Scout</h1>
+        <p class="subtitle">Track Malaysia laptop prices</p>
+      </header>
+      <section class="search">
+        <label for="query">Laptop model or title</label>
+        <input type="text" id="query" placeholder="e.g. Dell Latitude 7490" />
+      </section>
+      <section class="providers">
+        <h2>Data sources</h2>
+        <label>
+          <input type="checkbox" value="serpapi" checked disabled />
+          Google Shopping (SerpAPI)
+          <span class="tag stable">stable</span>
+        </label>
+        <label>
+          <input type="checkbox" value="shopee" />
+          Shopee
+          <span class="tag experimental">experimental</span>
+        </label>
+        <label>
+          <input type="checkbox" value="lazada" />
+          Lazada
+          <span class="tag experimental">experimental</span>
+        </label>
+        <label>
+          <input type="checkbox" value="tiktok" />
+          TikTok Shop
+          <span class="tag experimental">experimental</span>
+        </label>
+      </section>
+      <section class="sort">
+        <label for="sort">Sort results</label>
+        <select id="sort">
+          <option value="relevance">Relevance</option>
+          <option value="price">Price (MYR)</option>
+        </select>
+      </section>
+      <section class="actions">
+        <button id="search">Search</button>
+        <button id="export" disabled>Export CSV</button>
+      </section>
+      <section class="status" id="status"></section>
+      <section class="results" id="results"></section>
+    </main>
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,164 @@
+import { downloadCsv } from "./utils/csv.js";
+import { formatPrice } from "./utils/pricing.js";
+
+const queryInput = document.getElementById("query");
+const searchButton = document.getElementById("search");
+const exportButton = document.getElementById("export");
+const resultsContainer = document.getElementById("results");
+const statusElement = document.getElementById("status");
+const sortSelect = document.getElementById("sort");
+
+let latestResults = [];
+
+function getSelectedProviders() {
+  const checkboxes = document.querySelectorAll('.providers input[type="checkbox"]');
+  const selected = [];
+  for (const checkbox of checkboxes) {
+    if (checkbox.value === "serpapi") continue;
+    if (checkbox.checked) selected.push(checkbox.value);
+  }
+  return selected;
+}
+
+function renderResults(results) {
+  resultsContainer.innerHTML = "";
+  if (!results || results.length === 0) {
+    const empty = document.createElement("p");
+    empty.textContent = "No offers found yet.";
+    resultsContainer.appendChild(empty);
+    exportButton.disabled = true;
+    return;
+  }
+
+  for (const item of results) {
+    const card = document.createElement("article");
+    card.className = "result-card";
+
+    const header = document.createElement("div");
+    header.className = "result-header";
+
+    const titleLink = document.createElement("a");
+    titleLink.href = item.link;
+    titleLink.target = "_blank";
+    titleLink.rel = "noopener";
+    titleLink.textContent = item.title || "Unknown item";
+
+    const price = document.createElement("span");
+    price.className = "result-price";
+    let priceText = "Price unavailable";
+    if (item.normalizedPrice !== null && item.normalizedPrice !== undefined) {
+      priceText = formatPrice(item.normalizedPrice, "MYR");
+    } else if (item.price !== null && item.price !== undefined) {
+      priceText = `${item.currency || "MYR"} ${item.price}`;
+    }
+    price.textContent = priceText;
+
+    header.appendChild(titleLink);
+    header.appendChild(price);
+
+    const meta = document.createElement("p");
+    meta.textContent = `${item.marketplace || "Unknown marketplace"} • ${
+      item.seller || "Unknown seller"
+    }`;
+    meta.className = "result-meta";
+
+    card.appendChild(header);
+    card.appendChild(meta);
+    resultsContainer.appendChild(card);
+  }
+  exportButton.disabled = false;
+}
+
+function showStatus(message, tone = "info") {
+  statusElement.textContent = message;
+  statusElement.dataset.tone = tone;
+}
+
+function handleErrors(errors) {
+  if (!errors || errors.length === 0) {
+    showStatus("Ready.");
+    return;
+  }
+  const formatted = errors
+    .map((error) => `${error.providerId}: ${error.message}`)
+    .join(" | ");
+  showStatus(`Partial data - ${formatted}`, "warning");
+}
+
+function toCsvRows(results) {
+  return results.map((item) => ({
+    Title: item.title,
+    Marketplace: item.marketplace,
+    Seller: item.seller,
+    Link: item.link,
+    Price: item.price,
+    Currency: item.currency,
+    NormalizedMYR: item.normalizedPrice,
+  }));
+}
+
+async function runSearch() {
+  const query = queryInput.value.trim();
+  if (query.length < 3) {
+    showStatus("Enter at least 3 characters.", "error");
+    return;
+  }
+
+  showStatus("Fetching competitor prices…", "info");
+  resultsContainer.innerHTML = "";
+  exportButton.disabled = true;
+
+  const sortBy = sortSelect.value;
+  const providers = getSelectedProviders();
+
+  try {
+    const response = await chrome.runtime.sendMessage({
+      type: "FETCH_PRICES",
+      payload: { query, providers, sortBy },
+    });
+
+    if (!response) {
+      showStatus("No response from background script.", "error");
+      return;
+    }
+
+    if (response.error) {
+      showStatus(response.error, "error");
+      return;
+    }
+
+    latestResults = response.results || [];
+    renderResults(latestResults);
+    handleErrors(response.errors);
+  } catch (error) {
+    showStatus(error.message, "error");
+  }
+}
+
+searchButton.addEventListener("click", runSearch);
+queryInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    runSearch();
+  }
+});
+
+sortSelect.addEventListener("change", () => {
+  if (!latestResults.length) return;
+  const sorted = [...latestResults];
+  if (sortSelect.value === "price") {
+    sorted.sort((a, b) => {
+      const priceA = a.normalizedPrice ?? Number.POSITIVE_INFINITY;
+      const priceB = b.normalizedPrice ?? Number.POSITIVE_INFINITY;
+      return priceA - priceB;
+    });
+  }
+  renderResults(sorted);
+});
+
+exportButton.addEventListener("click", () => {
+  if (!latestResults.length) return;
+  const filename = `bbtech-prices-${Date.now()}.csv`;
+  downloadCsv(filename, toCsvRows(latestResults));
+});
+
+showStatus("Ready.");

--- a/popup.js
+++ b/popup.js
@@ -112,9 +112,20 @@ async function runSearch() {
   const providers = getSelectedProviders();
 
   try {
-    const response = await chrome.runtime.sendMessage({
-      type: "FETCH_PRICES",
-      payload: { query, providers, sortBy },
+    const response = await new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage(
+        {
+          type: "FETCH_PRICES",
+          payload: { query, providers, sortBy },
+        },
+        (messageResponse) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+          resolve(messageResponse);
+        }
+      );
     });
 
     if (!response) {

--- a/providers/lazada.js
+++ b/providers/lazada.js
@@ -1,0 +1,33 @@
+import { parsePrice, normalizeCurrency } from "../utils/pricing.js";
+
+const ENDPOINT = "https://www.lazada.com.my/catalog/";
+
+export async function fetchLazada(query) {
+  const params = new URLSearchParams({
+    ajax: "true",
+    q: query,
+    from: "input",
+  });
+
+  const response = await fetch(`${ENDPOINT}?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Lazada error: ${response.status}`);
+  }
+  const data = await response.json();
+  const items = data?.mods?.listItems;
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.map((item) => {
+    const { amount, currency } = parsePrice(item.price || item.discountPrice);
+    return {
+      title: item.name,
+      seller: item.sellerName,
+      marketplace: "Lazada",
+      link: item.productUrl ? `https:${item.productUrl}` : null,
+      price: amount,
+      currency: currency || item.currency || "MYR",
+      normalizedPrice: normalizeCurrency({ amount, currency: currency || item.currency || "MYR" }),
+    };
+  }).filter((item) => item.link);
+}

--- a/providers/serpapi.js
+++ b/providers/serpapi.js
@@ -1,0 +1,38 @@
+import { parsePrice, normalizeCurrency } from "../utils/pricing.js";
+
+const ENDPOINT = "https://serpapi.com/search.json";
+
+export async function fetchSerpApi(query, apiKey) {
+  if (!apiKey) {
+    throw new Error("Missing SerpAPI key. Set it in the options page.");
+  }
+
+  const params = new URLSearchParams({
+    engine: "google_shopping",
+    q: query,
+    location: "Malaysia",
+    hl: "en",
+    gl: "my",
+    api_key: apiKey,
+  });
+
+  const response = await fetch(`${ENDPOINT}?${params.toString()}`);
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`SerpAPI error: ${response.status} ${message}`);
+  }
+  const data = await response.json();
+  const items = data.shopping_results || [];
+  return items.map((item) => {
+    const { amount, currency } = parsePrice(item.extracted_price ?? item.price);
+    return {
+      title: item.title,
+      seller: item.source || item.store,
+      marketplace: "Google Shopping",
+      link: item.link,
+      price: amount,
+      currency: currency || item.currency || "MYR",
+      normalizedPrice: normalizeCurrency({ amount, currency: currency || item.currency || "MYR" }),
+    };
+  });
+}

--- a/providers/shopee.js
+++ b/providers/shopee.js
@@ -1,0 +1,37 @@
+import { normalizeCurrency } from "../utils/pricing.js";
+
+const ENDPOINT = "https://shopee.com.my/api/v4/search/search_items";
+
+export async function fetchShopee(query) {
+  const params = new URLSearchParams({
+    by: "relevancy",
+    keyword: query,
+    limit: "20",
+    newest: "0",
+    order: "desc",
+    page_type: "search",
+  });
+
+  const response = await fetch(`${ENDPOINT}?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Shopee error: ${response.status}`);
+  }
+  const data = await response.json();
+  if (!data || !Array.isArray(data.items)) {
+    return [];
+  }
+  return data.items.map((item) => {
+    const basic = item.item_basic;
+    if (!basic) return null;
+    const price = (basic.price ?? basic.price_min) / 100000;
+    return {
+      title: basic.name,
+      seller: basic.shop_location,
+      marketplace: "Shopee",
+      link: `https://shopee.com.my/${basic.name.replace(/\s+/g, "-")}-i.${basic.shopid}.${basic.itemid}`,
+      price,
+      currency: "MYR",
+      normalizedPrice: normalizeCurrency({ amount: price, currency: "MYR" }),
+    };
+  }).filter(Boolean);
+}

--- a/providers/tiktok.js
+++ b/providers/tiktok.js
@@ -1,0 +1,30 @@
+import { parsePrice, normalizeCurrency } from "../utils/pricing.js";
+
+const ENDPOINT = "https://www.tiktok.com/api/v1/product/search/";
+
+export async function fetchTikTok(query) {
+  const params = new URLSearchParams({
+    keyword: query,
+    region: "MY",
+    count: "20",
+  });
+
+  const response = await fetch(`${ENDPOINT}?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`TikTok Shop error: ${response.status}`);
+  }
+  const data = await response.json();
+  const items = data?.data?.products || [];
+  return items.map((item) => {
+    const { amount, currency } = parsePrice(item.price?.price_text);
+    return {
+      title: item.title,
+      seller: item.seller_name,
+      marketplace: "TikTok Shop",
+      link: item.detail_url,
+      price: amount,
+      currency: currency || item.currency || "MYR",
+      normalizedPrice: normalizeCurrency({ amount, currency: currency || item.currency || "MYR" }),
+    };
+  }).filter((item) => item.link);
+}

--- a/utils/csv.js
+++ b/utils/csv.js
@@ -1,0 +1,30 @@
+export function toCsv(rows) {
+  if (!rows || rows.length === 0) {
+    return "";
+  }
+  const header = Object.keys(rows[0]);
+  const escape = (value) => {
+    if (value === null || value === undefined) return "";
+    const stringValue = String(value).replace(/"/g, '""');
+    if (stringValue.search(/[",\n]/g) >= 0) {
+      return `"${stringValue}"`;
+    }
+    return stringValue;
+  };
+  const csvLines = [header.join(",")];
+  for (const row of rows) {
+    csvLines.push(header.map((key) => escape(row[key])).join(","));
+  }
+  return csvLines.join("\n");
+}
+
+export function downloadCsv(filename, rows) {
+  const csvString = toCsv(rows);
+  const blob = new Blob([csvString], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/utils/dedupe.js
+++ b/utils/dedupe.js
@@ -1,0 +1,31 @@
+const normalize = (value) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+export function dedupeResults(results) {
+  const seenLinks = new Set();
+  const seenTitles = new Set();
+  const deduped = [];
+
+  for (const item of results) {
+    if (!item) continue;
+    const linkKey = item.link ? item.link.split("?")[0] : "";
+    const titleKey = item.title ? normalize(item.title) : "";
+
+    const alreadySeen =
+      (linkKey && seenLinks.has(linkKey)) ||
+      (titleKey && seenTitles.has(titleKey));
+
+    if (alreadySeen) {
+      continue;
+    }
+
+    if (linkKey) seenLinks.add(linkKey);
+    if (titleKey) seenTitles.add(titleKey);
+    deduped.push(item);
+  }
+
+  return deduped;
+}

--- a/utils/pricing.js
+++ b/utils/pricing.js
@@ -1,0 +1,54 @@
+const FX_TABLE = {
+  MYR: 1,
+  SGD: 3.45,
+  USD: 4.7,
+  AUD: 3.1,
+  EUR: 5.1,
+  GBP: 5.9,
+};
+
+const CURRENCY_SYMBOLS = {
+  RM: "MYR",
+  MYR: "MYR",
+  SGD: "SGD",
+  S$: "SGD",
+  USD: "USD",
+  $: "USD",
+  AUD: "AUD",
+  A$: "AUD",
+  EUR: "EUR",
+  €: "EUR",
+  GBP: "GBP",
+  £: "GBP",
+};
+
+export function parsePrice(input) {
+  if (!input) return { amount: null, currency: null };
+  const trimmed = input.toString().replace(/[,\s]/g, "").toUpperCase();
+  const currencyMatch = trimmed.match(/(RM|MYR|SGD|S\$|USD|AUD|A\$|EUR|€|GBP|£)/i);
+  const currency = currencyMatch ? CURRENCY_SYMBOLS[currencyMatch[0].toUpperCase()] : null;
+  const amountMatch = trimmed.match(/([0-9]+(?:\.[0-9]+)?)/);
+  const amount = amountMatch ? Number(amountMatch[0]) : null;
+  return { amount, currency };
+}
+
+export function normalizeCurrency({ amount, currency }) {
+  if (amount === null || amount === undefined) {
+    return null;
+  }
+  const isoCode = currency ? currency.toUpperCase() : "MYR";
+  const fxRate = FX_TABLE[isoCode];
+  if (!fxRate) {
+    return null;
+  }
+  return Number((amount * (FX_TABLE.MYR / fxRate)).toFixed(2));
+}
+
+export function formatPrice(amount, currency = "MYR") {
+  if (amount === null || amount === undefined) return "N/A";
+  return new Intl.NumberFormat("en-MY", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+  }).format(amount);
+}


### PR DESCRIPTION
## Summary
- add a shared SerpAPI key constant and helper so the background worker falls back when no stored key exists
- preload the options page with the shared key and update the setup documentation to explain the default credential

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68dcf9d230248325b924791052ebb051