### PR TITLE
Fix currency normalization multiplier

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/utils/pricing.js
+++ b/utils/pricing.js
@@ -17,9 +17,9 @@ const CURRENCY_SYMBOLS = {
   AUD: "AUD",
   A$: "AUD",
   EUR: "EUR",
-  €: "EUR",
+  "\u20AC": "EUR",
   GBP: "GBP",
-  £: "GBP",
+  "\u00A3": "GBP",
 };
 
 export function parsePrice(input) {
@@ -41,7 +41,7 @@ export function normalizeCurrency({ amount, currency }) {
   if (!fxRate) {
     return null;
   }
-  return Number((amount * (FX_TABLE.MYR / fxRate)).toFixed(2));
+  return Number((amount * fxRate).toFixed(2));
 }
 
 export function formatPrice(amount, currency = "MYR") {

--- a/utils/pricing.test.mjs
+++ b/utils/pricing.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { normalizeCurrency } from "./pricing.js";
+
+assert.equal(
+  normalizeCurrency({ amount: 100, currency: "SGD" }),
+  345
+);
+assert.equal(
+  normalizeCurrency({ amount: 100, currency: "MYR" }),
+  100
+);
+
+console.log("All pricing normalization tests passed.");


### PR DESCRIPTION
## Summary
- update currency normalization to multiply by the FX rate for conversion to MYR
- adjust currency symbol mapping for compatibility with Node-based tests
- add a small regression test and module configuration under utils to guard against FX changes

## Testing
- node utils/pricing.test.mjs

------
https://chatgpt.com/codex/tasks/task_b_68de02b2ec0c8325b907cfb43252bf8a